### PR TITLE
WIP - steamclient: dont create interface for SteamController007 or SteamInp…

### DIFF
--- a/lsteamclient/steamclient_main.c
+++ b/lsteamclient/steamclient_main.c
@@ -4,6 +4,7 @@
 #include <dlfcn.h>
 #include <limits.h>
 #include <stdint.h>
+#include <fcntl.h>
 
 #include "windef.h"
 #include "winbase.h"
@@ -407,6 +408,17 @@ void *create_win_interface(const char *name, void *linux_side)
 
     if (!linux_side)
         return NULL;
+
+    int fd = open ("/dev/input/js0", O_RDONLY);
+
+    if(fd < 0)
+    {
+        if(!strcmp(name,"SteamController007") || !strcmp(name,"SteamInput001"))
+        {
+            TRACE("No input devices detected, disabling: %s\n", name);
+            return NULL;
+        }
+    }
 
     EnterCriticalSection(&steamclient_cs);
 

--- a/lsteamclient/steamclient_main.c
+++ b/lsteamclient/steamclient_main.c
@@ -4,7 +4,8 @@
 #include <dlfcn.h>
 #include <limits.h>
 #include <stdint.h>
-#include <fcntl.h>
+#include <dirent.h>
+#include <string.h>
 
 #include "windef.h"
 #include "winbase.h"
@@ -409,11 +410,27 @@ void *create_win_interface(const char *name, void *linux_side)
     if (!linux_side)
         return NULL;
 
-    int fd = open ("/dev/input/js0", O_RDONLY);
 
-    if(fd < 0)
+    if(!strcmp(name,"SteamController007") || !strcmp(name,"SteamInput001"))
     {
-        if(!strcmp(name,"SteamController007") || !strcmp(name,"SteamInput001"))
+        DIR *d;
+        struct dirent *dir;
+        d = opendir("/dev/input/by-id");
+        int js = 0;
+
+        if(d)
+        {
+            while ((dir = readdir(d)) != NULL)
+            {
+                if(strstr(dir->d_name,"joystick") || strstr(dir->d_name,"Valve_Software_Wired_Controller"))
+                {
+                    js++;
+                    break;
+                }
+            }
+            closedir(d);
+        }
+        if(js<1)
         {
             TRACE("No input devices detected, disabling: %s\n", name);
             return NULL;


### PR DESCRIPTION
…ut001 without a controller

This allows the controller config profile to be loaded only if a controller is plugged in, and otherwise disallows SteamController007 and SteamInput001 from loading - there is no point in loading these if we are not using a controller.

This allows warframe to not crash after 5 minutes without a controller, and still allows full functionality if a controller is actually plugged in. Details:

https://github.com/ValveSoftware/Proton/issues/167#issuecomment-596275091

Also - hotplugging continues to function properly.

Caveats:
If a game has multiple controller config -layers- such as warframe, and the game is not started with a controller, the game will need to be restarted if a controller is plugged in after starting, otherwise only the first controller layer will be applied.